### PR TITLE
[Feat] 타이핑 시작 시 경과시간 측정

### DIFF
--- a/DailyTyping/DailyTyping/Sources/Component/SpeedMeasurementView.swift
+++ b/DailyTyping/DailyTyping/Sources/Component/SpeedMeasurementView.swift
@@ -57,4 +57,12 @@ final class SpeedMeasurementView: BaseView {
         backgroundColor = .primaryEmphasis
     }
 
+    func setElapsedTime(second: Int) {
+        progressTimeLabel.text = getSecondText(second: second)
+    }
+    
+    func getSecondText(second: Int) -> String {
+        let resultSecond = String.getFormattedTwoDigit(number: second)
+        return second != 60 ? "00:00:\(resultSecond)" : "00:01:00"
+    }
 }

--- a/DailyTyping/DailyTyping/Sources/Coordinator/MainCoordinator.swift
+++ b/DailyTyping/DailyTyping/Sources/Coordinator/MainCoordinator.swift
@@ -17,7 +17,7 @@ final class MainCoordinator: Coordinator {
     }
     
     func start() {
-        let viewModel = TypingViewModel()
+        let viewModel = TypingViewModel(timeProvider: TimerManager())
         let mainVC = TypingViewController(viewModel: viewModel)
         mainVC.coordinator = self
         navigationController.pushViewController(mainVC, animated: false)

--- a/DailyTyping/DailyTyping/Sources/Extensions/Extension/String+format.swift
+++ b/DailyTyping/DailyTyping/Sources/Extensions/Extension/String+format.swift
@@ -1,0 +1,12 @@
+//
+//  String+format.swift
+//  DailyTyping
+//
+//  Created by 조유진 on 2/12/25.
+//
+
+extension String {
+    static func getFormattedTwoDigit(number: Int) -> String {
+        return String(format: "%02d", number)
+    }
+}

--- a/DailyTyping/DailyTyping/Sources/Extensions/UIExtension/UITextView+combine.swift
+++ b/DailyTyping/DailyTyping/Sources/Extensions/UIExtension/UITextView+combine.swift
@@ -1,0 +1,22 @@
+//
+//  UITextView+combine.swift
+//  DailyTyping
+//
+//  Created by 조유진 on 2/12/25.
+//
+
+import UIKit
+import Combine
+
+extension UITextView {
+
+    var textPublisher: AnyPublisher<String, Never> {
+        NotificationCenter.default.publisher(
+            for: UITextView.textDidChangeNotification,
+            object: self
+        )
+        .compactMap { ($0.object as? UITextView)?.text }
+        .eraseToAnyPublisher()
+    }
+
+}

--- a/DailyTyping/DailyTyping/Sources/Manager/TimerManager.swift
+++ b/DailyTyping/DailyTyping/Sources/Manager/TimerManager.swift
@@ -9,7 +9,7 @@ import Foundation
 import Combine
 
 protocol TimeProvider {
-    func timerPublisher(every seconds: TimeInterval) -> AnyPublisher<Int, Never>
+    func timerPublisher(every seconds: TimeInterval, endSeconds: Int) -> AnyPublisher<Int, Never>
 }
 
 final class TimerManager: TimeProvider {

--- a/DailyTyping/DailyTyping/Sources/Manager/TimerManager.swift
+++ b/DailyTyping/DailyTyping/Sources/Manager/TimerManager.swift
@@ -1,0 +1,25 @@
+//
+//  TimerManager.swift
+//  DailyTyping
+//
+//  Created by 조유진 on 2/12/25.
+//
+
+import Foundation
+import Combine
+
+protocol TimeProvider {
+    func timerPublisher(every seconds: TimeInterval) -> AnyPublisher<Int, Never>
+}
+
+final class TimerManager: TimeProvider {
+    func timerPublisher(every seconds: TimeInterval = 1.0, endSeconds: Int = 60) -> AnyPublisher<Int, Never> {
+        Timer.publish(every: seconds, on: .main, in: .common)
+            .autoconnect()
+            .scan(0) { seconds, _ in
+                seconds + 1
+            }
+            .prefix(endSeconds)
+            .eraseToAnyPublisher()
+    }
+}

--- a/DailyTyping/DailyTyping/Sources/Scenes/Typing/View/TypingView.swift
+++ b/DailyTyping/DailyTyping/Sources/Scenes/Typing/View/TypingView.swift
@@ -33,7 +33,7 @@ final class TypingView: BaseView {
     
     private let speedMeasurementView = SpeedMeasurementView()
     private let placeholderTextView = PlaceholderTextView()
-    private let typingTextView = PlaceholderTextView()
+    let typingTextView = PlaceholderTextView()
     let typingInputAccessoryView = TypingInputAccessoryView()
     
     
@@ -50,6 +50,7 @@ final class TypingView: BaseView {
         placeholderTextView.configureView(textValue: TypingLabelText.typingValue.rawValue)
         typingTextView.configureView(textValue: "", isPlaceHolder: false)
         typingTextView.inputAccessoryView = typingInputAccessoryView
+        typingTextView.autocorrectionType = .no
         setTextViewFirstResponder()
     }
     

--- a/DailyTyping/DailyTyping/Sources/Scenes/Typing/View/TypingView.swift
+++ b/DailyTyping/DailyTyping/Sources/Scenes/Typing/View/TypingView.swift
@@ -61,4 +61,8 @@ final class TypingView: BaseView {
     func addBorderToTypingInfoView() {
         typingInputAccessoryView.addBorderToTypingInfoView()
     }
+    
+    func setElapsedTime(second: Int) {
+        speedMeasurementView.setElapsedTime(second: second)
+    }
 }

--- a/DailyTyping/DailyTyping/Sources/Scenes/Typing/View/TypingViewController.swift
+++ b/DailyTyping/DailyTyping/Sources/Scenes/Typing/View/TypingViewController.swift
@@ -44,7 +44,8 @@ final class TypingViewController: BaseViewController {
         guard let viewModel = viewModel as? TypingViewModel else { return }
         let input = TypingViewModel.Input(
             historyButtonTapped: mainView.historyButton.tapPublisher,
-            linkButtonTapped: mainView.typingInputAccessoryView.linkButton.tapPublisher
+            linkButtonTapped: mainView.typingInputAccessoryView.linkButton.tapPublisher,
+            textViewDidChanged: mainView.typingTextView.textPublisher
         )
         
         let output = viewModel.transform(input: input)

--- a/DailyTyping/DailyTyping/Sources/Scenes/Typing/View/TypingViewController.swift
+++ b/DailyTyping/DailyTyping/Sources/Scenes/Typing/View/TypingViewController.swift
@@ -63,6 +63,13 @@ final class TypingViewController: BaseViewController {
                 coordinator.showLinkWebVC()
             }
             .store(in: &cancellables)
+        
+        output.elapsedTime
+            .sink { [weak self] second in
+                guard let self else { return }
+                mainView.setElapsedTime(second: second)
+            }
+            .store(in: &cancellables)
     }
     
     override func configureNavigationItem() {

--- a/DailyTyping/DailyTyping/Sources/Scenes/Typing/ViewModel/TypingViewModel.swift
+++ b/DailyTyping/DailyTyping/Sources/Scenes/Typing/ViewModel/TypingViewModel.swift
@@ -13,6 +13,7 @@ final class TypingViewModel: ViewModelType{
     struct Input {
         let historyButtonTapped: AnyPublisher<Void, Never>
         let linkButtonTapped: AnyPublisher<Void, Never>
+        let textViewDidChanged: AnyPublisher<String, Never>
     }
     
     struct Output {
@@ -26,6 +27,17 @@ final class TypingViewModel: ViewModelType{
         
         let linkButtonTapped = input.linkButtonTapped
             .eraseToAnyPublisher()
+        
+        // 처음으로 빈 문자열이 아닌 값이 입력되었을 때 이벤트 방출
+        let typingStart = input.textViewDidChanged
+            .filter { !$0.isEmpty }
+            .prefix(1)  // 처음 방출 이후 스트림 완료 -> 더 이상 구독 X
+            .eraseToAnyPublisher()
+        
+        typingStart.sink { text in
+            print(text)
+        }
+        .store(in: &cancellables)
         
         return Output(
             historyButtonTapped: historyButtonTapped,


### PR DESCRIPTION
## 🔍 What is this PR?
- 타이핑 시작 시 경과시간 측정 및 화면에 표시

## 📝 Changes
- UITextView+combine을 구성하여 타이핑이 처음 시작하는 이벤트 방출하도록 구현
- TimerProvider Protocol 정의 및 TimerManager 구성
- `var elapsedTimePublisher = PassthroughSubject<Int, Never>()` 를 통해 경과 시간 값 보내기
- 경과시간 progressTimeLabel에 적용